### PR TITLE
исправление некоторых расхождений со спецификацией на cbor

### DIFF
--- a/cbor.cpp
+++ b/cbor.cpp
@@ -117,7 +117,7 @@ inline QVariant _unpack(QByteArray &data) {
             } break;
             case MajorType::str: {
                 auto sz = static_cast<int>(parseHeader(data));
-                ret     = QString(data.mid(0, sz));
+                ret     = QString::fromUtf8(data.mid(0, sz));
                 data    = data.mid(sz);
             } break;
             case MajorType::array: {
@@ -199,9 +199,9 @@ QByteArray CBOR::pack(const QVariant &v) {
             ret += b;
         } break;
         case QVariant::String: {
-            auto s = v.toString();
+            auto s = v.toString().toUtf8();
             ret += mkHeaderEx(MajorType::str, static_cast<quint64>(s.length()));
-            ret += s.toLocal8Bit();
+            ret += s;
         } break;
         case QVariant::List: {
             auto array = v.toList();

--- a/cbor.cpp
+++ b/cbor.cpp
@@ -151,12 +151,14 @@ inline QVariant _unpack(QByteArray &data) {
                 } else if (st == OtherType::null_) {
                     ret = QVariant();
                 } else if (st == OtherType::float32) {
-                    auto fPtr = reinterpret_cast<float *>(data.data());
-                    ret       = double(*fPtr);
+                    float out=0.;
+                    qbswap(*(const float *)data.constData(), reinterpret_cast<uchar *>(&out));
+                    ret       = out;
                     data      = data.mid(4);
                 } else if (st == OtherType::float64) {
-                    auto fPtr = reinterpret_cast<double *>(data.data());
-                    ret       = *fPtr;
+                    double out=0.;
+                    qbswap(*(const double *)data.constData(), reinterpret_cast<uchar *>(&out));
+                    ret       = out;
                     data      = data.mid(8);
                 }
             } break;
@@ -189,9 +191,8 @@ QByteArray CBOR::pack(const QVariant &v) {
             ret += mkHeaderEx(MajorType::positiveInt, v.toULongLong());
         } break;
         case QVariant::Double: {
-            double val = v.toDouble();
             ret += mkHeader(MajorType::other, OtherType::float64);
-            ret.append(reinterpret_cast<char *>(&val), 8);
+            ret.append(nativeToBigEndian(v.toDouble()));
         } break;
         case QVariant::ByteArray: {
             auto b = v.toByteArray();

--- a/cbor.cpp
+++ b/cbor.cpp
@@ -4,6 +4,7 @@
 #include <QTime>
 #include <QDate>
 #include <QDateTime>
+#include <QStringList>
 
 namespace CBOR {
 


### PR DESCRIPTION
1. строки - тип 3 кодируются в utf8:
>Major type 3:  a text string, specifically a string of Unicode characters that is encoded as UTF-8 [RFC3629].  The format of this type is identical to that of byte strings (major type 2), that is, as with major type 2, the length gives the number of bytes.
2. преобразование очередности байт в big-endian для double-типа
>All multi-byte values are encoded in network byte order (that is, most significant byte first, also known as "big-endian")
3. совсем мелочь, но кому-нибудь может пригодиться - без инклюда QStringList не собирается в qt4